### PR TITLE
Implemented DataTemplateSelector to the grid on Search Page

### DIFF
--- a/UniTube.Core/Requests/SearchListRequest.cs
+++ b/UniTube.Core/Requests/SearchListRequest.cs
@@ -232,7 +232,7 @@ namespace UniTube.Core.Requests
                 new KeyValuePair<string, string>("relevanceLanguage", RelevanceLangugage),
                 new KeyValuePair<string, string>("safeSearch", SafeSearch.ToString()),
                 new KeyValuePair<string, string>("topicId", TopicId),
-                new KeyValuePair<string, string>("type", Type.ToString()),
+                new KeyValuePair<string, string>("type", Type.ToString().ToLower()),
                 new KeyValuePair<string, string>("videoCaption", VideoCaption.ToString()),
                 new KeyValuePair<string, string>("videoCategoryId", VideoCategoryId),
                 new KeyValuePair<string, string>("videoDefinition", VideoDefinition.ToString()),

--- a/UniTube.Core/Resources/Channel.cs
+++ b/UniTube.Core/Resources/Channel.cs
@@ -3,7 +3,7 @@ using UniTube.Core.Requests;
 
 namespace UniTube.Core.Resources
 {
-    public class Channel
+    public class Channel : ISearchResult
     {
         public string Kind { get; set; }
         public string Etag { get; set; }

--- a/UniTube.Core/Resources/ISearchResult.cs
+++ b/UniTube.Core/Resources/ISearchResult.cs
@@ -1,0 +1,7 @@
+﻿namespace UniTube.Core.Resources
+{
+    public interface ISearchResult
+    {
+
+    }
+}

--- a/UniTube.Core/Resources/Playlist.cs
+++ b/UniTube.Core/Resources/Playlist.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace UniTube.Core.Resources
+{
+    public class Playlist : ISearchResult
+    {
+        public string Kind { get; set; }
+        public string Etag { get; set; }
+        public string Id { get; set; }
+        public PlaylistSnippet Snippet { get; set; }
+
+        public class PlaylistSnippet
+        {
+            public DateTime PublishedAt { get; set; }
+            public string ChannelId { get; set; }
+            public string Title { get; set; }
+            public string Description { get; set; }
+            public Thumbnails Thumbnails { get; set; }
+            public string ChannelTitle { get; set; }
+            public List<string> Tags { get; set; }
+        }
+    }
+}

--- a/UniTube.Core/Resources/Video.cs
+++ b/UniTube.Core/Resources/Video.cs
@@ -4,7 +4,7 @@ using UniTube.Core.Requests;
 
 namespace UniTube.Core.Resources
 {
-    public class Video
+    public class Video : ISearchResult
     {
         public string Kind { get; set; }
         public string Etag { get; set; }

--- a/UniTube.Core/UniTube.Core.csproj
+++ b/UniTube.Core/UniTube.Core.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Requests\SuggestionListRequest.cs" />
     <Compile Include="Requests\VideoListRequest.cs" />
     <Compile Include="Resources\Channel.cs" />
+    <Compile Include="Resources\ISearchResult.cs" />
     <Compile Include="Resources\Search.cs" />
     <Compile Include="Resources\SearchResult.cs" />
     <Compile Include="Resources\Thumbnails.cs" />

--- a/UniTube.Core/UniTube.Core.csproj
+++ b/UniTube.Core/UniTube.Core.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Requests\VideoListRequest.cs" />
     <Compile Include="Resources\Channel.cs" />
     <Compile Include="Resources\ISearchResult.cs" />
+    <Compile Include="Resources\Playlist.cs" />
     <Compile Include="Resources\Search.cs" />
     <Compile Include="Resources\SearchResult.cs" />
     <Compile Include="Resources\Thumbnails.cs" />

--- a/UniTube/Converters/DateTimeToStringConverter.cs
+++ b/UniTube/Converters/DateTimeToStringConverter.cs
@@ -8,127 +8,68 @@ namespace UniTube.Converters
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            if (value is DateTime)
+            if (value is DateTime dateTime)
             {
-                DateTime date1 = (DateTime)value;
-                TimeSpan timeSpan = date1.Subtract(DateTime.Now);
-                if (-(timeSpan.Seconds) <= 59 && timeSpan.Hours == 0 && timeSpan.Minutes == 0 && timeSpan.Days == 0)
+                var timeSpan = DateTime.Now - dateTime;
+                if (timeSpan < TimeSpan.FromMinutes(1))
                 {
-                    return "Hace unos segundos";
+                    return "A few seconds ago";
                 }
-                if (-(timeSpan.Minutes) <= 10 && -(timeSpan.Minutes) >= 1 && timeSpan.Hours == 0 && timeSpan.Days == 0)
+                else if (timeSpan <= TimeSpan.FromMinutes(10) && timeSpan > TimeSpan.FromMinutes(1))
                 {
-                    return "Hace unos minutos";
+                    return "A few minutes ago";
                 }
-                if (-(timeSpan.Minutes) <= 59 && -(timeSpan.Minutes) > 10 && timeSpan.Hours == 0 && timeSpan.Days == 0)
+                else if (timeSpan < TimeSpan.FromHours(1) && timeSpan > TimeSpan.FromMinutes(10))
                 {
-                    return "Hace " + -(timeSpan.Minutes) + " minutos";
+                    return $"{timeSpan.Minutes} minutes ago";
                 }
-                if (-(timeSpan.Hours) == 1 && timeSpan.Days == 0)
+                else if (timeSpan == TimeSpan.FromHours(1))
                 {
-                    return "Hace una hora";
+                    return "An hour ago";
                 }
-                if (-(timeSpan.Hours) <= 23 && -(timeSpan.Minutes) < 59 && -(timeSpan.Hours) > 1 && timeSpan.Days == 0)
+                else if (timeSpan < TimeSpan.FromDays(1) && timeSpan > TimeSpan.FromHours(1))
                 {
-                    return "Hace " + -(timeSpan.Hours) + " horas";
+                    return $"{timeSpan.Hours} hours ago";
                 }
-                if (-(timeSpan.Days) == 1)
+                else if (timeSpan == TimeSpan.FromDays(1))
                 {
-                    return "Hace un dia";
+                    return "A day ago";
                 }
-                if (-(timeSpan.Days) <= 7 && -(timeSpan.Days) > 1)
+                else if (timeSpan < TimeSpan.FromDays(7) && timeSpan > TimeSpan.FromDays(1))
                 {
-                    return "Hace " + -(timeSpan.Days) + " dias";
+                    return $"{timeSpan.Days} days ago";
                 }
-                if (-(timeSpan.Days) <= 31 && -(timeSpan.Days) > 7)
+                else if (timeSpan == TimeSpan.FromDays(7))
                 {
-                    int week = 1;
-                    return "Hace una semana";
-                    if (-(timeSpan.Days) > 7)
-                    {
-                        week = 2;
-                        return "Hace " + week + " semanas";
-                    }
-                    if (-(timeSpan.Days) > 14)
-                    {
-                        week = 3;
-                        return "Hace " + week + " semanas";
-                    }
-                    if (-(timeSpan.Days) > 28)
-                    {
-                        week = 4;
-                        return "Hace " + week + " semanas";
-                    }
-
+                    return "A week ago";
                 }
-                if (-(timeSpan.Days) < 365 && -(timeSpan.Days) > 31)
+                else if (timeSpan < TimeSpan.FromDays(30) && timeSpan > TimeSpan.FromDays(7))
                 {
-                    int month = 1;
-                    return "Hace un mes";
-                    if (-(timeSpan.Days) >= 56)
-                    {
-                        month = 2;
-                        return "Hace " + month + " meses";
-                    }
-                    if (-(timeSpan.Days) >= 84)
-                    {
-                        month = 3;
-                        return "Hace " + month + " meses";
-                    }
-                    if (-(timeSpan.Days) >= 112)
-                    {
-                        month = 4;
-                        return "Hace " + month + " meses";
-                    }
-                    if (-(timeSpan.Days) >= 140)
-                    {
-                        month = 5;
-                        return "Hace " + month + " meses";
-                    }
-                    if (-(timeSpan.Days) >= 168)
-                    {
-                        month = 6;
-                        return "Hace " + month + " meses";
-                    }
-                    if (-(timeSpan.Days) >= 196)
-                    {
-                        month = 7;
-                        return "Hace " + month + " meses";
-                    }
-                    if (-(timeSpan.Days) >= 224)
-                    {
-                        month = 8;
-                        return "Hace " + month + " meses";
-                    }
-                    if (-(timeSpan.Days) >= 252)
-                    {
-                        month = 9;
-                        return "Hace " + month + " meses";
-                    }
-                    if (-(timeSpan.Days) >= 280)
-                    {
-                        month = 10;
-                        return "Hace " + month + " meses";
-                    }
-                    if (-(timeSpan.Days) >= 308)
-                    {
-                        month = 11;
-                        return "Hace " + month + " meses";
-                    }
-                    if (-(timeSpan.Days) >= 336)
-                    {
-                        month = 12;
-                        return "Hace " + month + " meses";
-                    }
+                    return $"{Math.Truncate(timeSpan.Days / 7d)} weeks ago";
+                }
+                else if (timeSpan == TimeSpan.FromDays(30))
+                {
+                    return "A month ago";
+                }
+                else if (timeSpan < TimeSpan.FromDays(365) && timeSpan > TimeSpan.FromDays(30))
+                {
+                    return $"{Math.Truncate(timeSpan.Days / 30d)} months ago";
+                }
+                else if (timeSpan == TimeSpan.FromDays(365))
+                {
+                    return "A year ago";
+                }
+                else if (timeSpan > TimeSpan.FromDays(365))
+                {
+                    return $"{Math.Truncate(timeSpan.Days / 365d)} years ago";
                 }
             }
             else if (value is null)
             {
-                return "None";
+                return string.Empty;
             }
 
             throw new NotImplementedException();
-
         }
         
 

--- a/UniTube/DataTemplateSelectors/ResourceTemplateSelector.cs
+++ b/UniTube/DataTemplateSelectors/ResourceTemplateSelector.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using UniTube.Core.Resources;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace UniTube.DataTemplateSelectors
+{
+    public class ResourceTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate VideoTemplate { get; set; }
+        public DataTemplate ChannelTemplate { get; set; }
+        public DataTemplate PlaylistTemplate { get; set; }
+
+        protected override DataTemplate SelectTemplateCore(object item)
+        {
+            if (item is Video)
+            {
+                return VideoTemplate;
+            }
+            else if (item is Channel)
+            {
+                return ChannelTemplate;
+            }
+            else if (item is Playlist)
+            {
+                return PlaylistTemplate;
+            }
+
+            throw new NotImplementedException();
+        }
+
+        protected override DataTemplate SelectTemplateCore(object item, DependencyObject container)
+            => SelectTemplateCore(item);
+    }
+}

--- a/UniTube/Sources/SearchSource.cs
+++ b/UniTube/Sources/SearchSource.cs
@@ -65,7 +65,7 @@ namespace UniTube.Sources
                 searchListRequest.PageToken = nextPageToken;
                 searchListRequest.RelevanceLangugage = GlobalizationPreferences.Languages[0];
                 searchListRequest.Key = Client.ApiKey;
-                searchListRequest.Fields = "nextPageToken,pageInfo/totalResults,items(id(kind,videoId,channelId,playlistId),snippet(title,channelTitle,thumbnails/high/url))";
+                searchListRequest.Fields = "nextPageToken,pageInfo/totalResults,items(id(kind,videoId,channelId,playlistId),snippet(title,channelTitle,channelId,publishedAt,description,thumbnails/high/url))";
                 searchListRequest.Type = SearchListRequest.TypeEnum.Video;
 
                 return await searchListRequest.ExecuteAsync();
@@ -82,9 +82,12 @@ namespace UniTube.Sources
                             Kind = searchResult.Id.Kind,
                             Snippet = new Video.VideoSnippet
                             {
+                                ChannelId = searchResult.Snippet.ChannelId,
+                                PublishedAt = searchResult.Snippet.PublishedAt,
                                 ChannelTitle = searchResult.Snippet.ChannelTitle,
                                 Title = searchResult.Snippet.Title,
-                                Thumbnails = searchResult.Snippet.Thumbnails
+                                Thumbnails = searchResult.Snippet.Thumbnails,
+                                Description = searchResult.Snippet.Description
                             }
                         };
                         _search.Add(video);
@@ -96,8 +99,10 @@ namespace UniTube.Sources
                             Kind = searchResult.Id.Kind,
                             Snippet = new Channel.ChannelSnippet
                             {
+                                PublishedAt = searchResult.Snippet.PublishedAt,
                                 Thumbnails = searchResult.Snippet.Thumbnails,
-                                Title = searchResult.Snippet.Title
+                                Title = searchResult.Snippet.Title,
+                                Description = searchResult.Snippet.Description
                             }
                         };
                         _search.Add(channel);
@@ -109,9 +114,12 @@ namespace UniTube.Sources
                             Kind = searchResult.Id.Kind,
                             Snippet = new Playlist.PlaylistSnippet
                             {
+                                PublishedAt = searchResult.Snippet.PublishedAt,
                                 ChannelTitle = searchResult.Snippet.ChannelTitle,
                                 Thumbnails = searchResult.Snippet.Thumbnails,
-                                Title = searchResult.Snippet.Title
+                                Title = searchResult.Snippet.Title,
+                                Description = searchResult.Snippet.Description,
+                                ChannelId = searchResult.Snippet.ChannelId
                             }
                         };
                         _search.Add(playlist);

--- a/UniTube/Sources/SearchSource.cs
+++ b/UniTube/Sources/SearchSource.cs
@@ -67,7 +67,6 @@ namespace UniTube.Sources
                 searchListRequest.RelevanceLangugage = GlobalizationPreferences.Languages[0];
                 searchListRequest.Key = Client.ApiKey;
                 searchListRequest.Fields = "nextPageToken,pageInfo/totalResults,items(id(kind,videoId,channelId,playlistId),snippet(title,channelTitle,channelId,publishedAt,description,thumbnails/high/url))";
-                searchListRequest.Type = SearchListRequest.TypeEnum.Video;
 
                 return await searchListRequest.ExecuteAsync();
             });

--- a/UniTube/Sources/SearchSource.cs
+++ b/UniTube/Sources/SearchSource.cs
@@ -65,7 +65,8 @@ namespace UniTube.Sources
                 searchListRequest.PageToken = nextPageToken;
                 searchListRequest.RelevanceLangugage = GlobalizationPreferences.Languages[0];
                 searchListRequest.Key = Client.ApiKey;
-                searchListRequest.Fields = "nextPageToken,pageInfo/totalResults,items(id/videoId,snippet(title,channelTitle,thumbnails/high/url))";
+                searchListRequest.Fields = "nextPageToken,pageInfo/totalResults,items(id(kind,videoId,channelId,playlistId),snippet(title,channelTitle,thumbnails/high/url))";
+                searchListRequest.Type = SearchListRequest.TypeEnum.Video;
 
                 return await searchListRequest.ExecuteAsync();
             });
@@ -77,15 +78,11 @@ namespace UniTube.Sources
                     case "youtube#video":
                         var video = new Video
                         {
-                            Etag = searchResult.Etag,
                             Id = searchResult.Id.VideoId,
                             Kind = searchResult.Id.Kind,
                             Snippet = new Video.VideoSnippet
                             {
-                                ChannelId = searchResult.Snippet.ChannelId,
                                 ChannelTitle = searchResult.Snippet.ChannelTitle,
-                                PublishedAt = searchResult.Snippet.PublishedAt,
-                                Description = searchResult.Snippet.Description,
                                 Title = searchResult.Snippet.Title,
                                 Thumbnails = searchResult.Snippet.Thumbnails
                             }
@@ -95,13 +92,10 @@ namespace UniTube.Sources
                     case "youtube#channel":
                         var channel = new Channel
                         {
-                            Etag = searchResult.Etag,
                             Id = searchResult.Id.ChannelId,
                             Kind = searchResult.Id.Kind,
                             Snippet = new Channel.ChannelSnippet
                             {
-                                Description = searchResult.Snippet.Description,
-                                PublishedAt = searchResult.Snippet.PublishedAt,
                                 Thumbnails = searchResult.Snippet.Thumbnails,
                                 Title = searchResult.Snippet.Title
                             }
@@ -111,15 +105,11 @@ namespace UniTube.Sources
                     case "youtube#playlist":
                         var playlist = new Playlist
                         {
-                            Etag = searchResult.Etag,
                             Id = searchResult.Id.PlaylistId,
                             Kind = searchResult.Id.Kind,
                             Snippet = new Playlist.PlaylistSnippet
                             {
-                                ChannelId = searchResult.Snippet.ChannelId,
-                                PublishedAt = searchResult.Snippet.PublishedAt,
                                 ChannelTitle = searchResult.Snippet.ChannelTitle,
-                                Description = searchResult.Snippet.Description,
                                 Thumbnails = searchResult.Snippet.Thumbnails,
                                 Title = searchResult.Snippet.Title
                             }

--- a/UniTube/Sources/SearchSource.cs
+++ b/UniTube/Sources/SearchSource.cs
@@ -15,6 +15,7 @@ namespace UniTube.Sources
 {
     public class SearchSource : IIncrementalSource<SearchResult>
     {
+        private bool _hasBeenLoaded;
         private string _nextPageToken;
         private string _query;
         private int _totalResults = 1;
@@ -34,14 +35,14 @@ namespace UniTube.Sources
         {
             if (_search.Count < _totalResults && _search.Count < ((pageIndex + 1) * pageSize))
             {
-                if (_search.Count == 0)
+                if (!_hasBeenLoaded)
                 {
                     _startFirstLoadAction?.Invoke();
                 }
 
                 await PopulateSearchList(_nextPageToken);
 
-                if (_search.Count == 50)
+                if (_hasBeenLoaded)
                 {
                     _endFirstLoadAction?.Invoke();
                 }
@@ -73,6 +74,7 @@ namespace UniTube.Sources
             _search.AddRange(response.Items);
             _nextPageToken = response.NextPageToken;
             _totalResults = response.PageInfo.TotalResults;
+            _hasBeenLoaded = true;
         }
     }
 }

--- a/UniTube/Sources/TrendingSource.cs
+++ b/UniTube/Sources/TrendingSource.cs
@@ -15,6 +15,7 @@ namespace UniTube.Sources
 {
     public class TrendingSource : IIncrementalSource<Video>
     {
+        private bool _hasBeenLoaded;
         private string _nextPageToken;
         private int _totalResults = 1;
         private readonly List<Video> _trending;
@@ -32,7 +33,7 @@ namespace UniTube.Sources
         {
             if (_trending.Count < _totalResults && _trending.Count < ((pageIndex + 1) * pageSize))
             {
-                if (_trending.Count == 0)
+                if (!_hasBeenLoaded)
                 {
                     _startFirstLoadAction?.Invoke();
                 }
@@ -40,7 +41,7 @@ namespace UniTube.Sources
                 await PopulateTrendingList(_nextPageToken);
 
                 // TODO: this is not the best way to determine if invoke or not the en action
-                if (_trending.Count == 50)
+                if (_hasBeenLoaded)
                 {
                     _endFirstLoadAction?.Invoke();
                 }
@@ -73,6 +74,7 @@ namespace UniTube.Sources
             _trending.AddRange(response.Items);
             _nextPageToken = response.NextPageToken;
             _totalResults = response.PageInfo.TotalResults;
+            _hasBeenLoaded = true;
         }
     }
 }

--- a/UniTube/UniTube.csproj
+++ b/UniTube/UniTube.csproj
@@ -253,10 +253,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="MvvmLight">
-      <Version>5.3.0</Version>
+      <Version>6.0.2</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>10.0.3</Version>

--- a/UniTube/UniTube.csproj
+++ b/UniTube/UniTube.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Collections\IncrementalLoadingCollection\IncrementalLoadingCollection.cs" />
     <Compile Include="Converters\DateTimeToStringConverter.cs" />
     <Compile Include="Converters\ThumbnailsToBitmapImageConverter.cs" />
+    <Compile Include="DataTemplateSelectors\ResourceTemplateSelector.cs" />
     <Compile Include="Sources\SearchSource.cs" />
     <Compile Include="Sources\TrendingSource.cs" />
     <Compile Include="Controls\Toolbar\Toolbar.cs" />

--- a/UniTube/ViewModels/SearchViewModel.cs
+++ b/UniTube/ViewModels/SearchViewModel.cs
@@ -18,7 +18,7 @@ namespace UniTube.ViewModels
         private SearchSource _searchSource;
         private string _query = string.Empty;
 
-        public IncrementalLoadingCollection<SearchSource, SearchResult> SearchList { get; private set; }
+        public IncrementalLoadingCollection<SearchSource, ISearchResult> SearchList { get; private set; }
 
         public override Task OnNavigatedToAsync(object parameter, NavigationMode mode, IDictionary<string, object> state)
         {
@@ -35,7 +35,7 @@ namespace UniTube.ViewModels
                 {
                     loading.IsLoading = false;
                 });
-                SearchList = new IncrementalLoadingCollection<SearchSource, SearchResult>(_searchSource,
+                SearchList = new IncrementalLoadingCollection<SearchSource, ISearchResult>(_searchSource,
                     onError: (ex) =>
                     {
                         loading.IsLoading = false;

--- a/UniTube/Views/SearchPage.xaml
+++ b/UniTube/Views/SearchPage.xaml
@@ -14,7 +14,6 @@
                  Source="{StaticResource Locator}" />
     </Page.DataContext>
 
-
     <Grid>
         
         <VisualStateManager.VisualStateGroups>
@@ -123,19 +122,12 @@
                                 <TextBlock Text="●" />
 
                                 <TextBlock Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
-<<<<<<< HEAD
-                                           Text="{x:Bind Snippet.ChannelTitle}"
+                                           Text="{x:Bind Snippet.PublishedAt, Converter={StaticResource DateTimeToStringConverter}}"
                                            TextTrimming="CharacterEllipsis"
                                            TextWrapping="NoWrap"
                                            x:Phase="2"
                                            Margin="5,0,0,0" />
-=======
-                                       Text="{x:Bind Snippet.PublishedAt, Converter={StaticResource DateTimeToStringConverter}}"
-                                       TextTrimming="CharacterEllipsis"
-                                       TextWrapping="NoWrap"
-                                       x:Phase="2"
-                                       Margin="5,0,0,0"/>
->>>>>>> search
+                                
                             </StackPanel>
 
                         </StackPanel>

--- a/UniTube/Views/SearchPage.xaml
+++ b/UniTube/Views/SearchPage.xaml
@@ -41,7 +41,7 @@
                 
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-        
+
         <GridView ItemsSource="{x:Bind ViewModel.SearchList, Mode=OneWay}"
                   SelectionMode="None"
                   IsItemClickEnabled="True"
@@ -53,9 +53,9 @@
                   ItemContainerTransitions="{StaticResource GridViewItemContainerTransitions}"
                   Padding="10 10 -5 5">
             <GridView.ItemTemplate>
-                <DataTemplate x:DataType="resources:SearchResult">
+                <DataTemplate x:DataType="resources:Video">
                     <Grid Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
-                        
+
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
@@ -65,19 +65,26 @@
                             <Rectangle Height="213.75"
                                        Width="380"
                                        Grid.RowSpan="1">
-                                    <Rectangle.Fill>
-                                        <ImageBrush ImageSource="{x:Bind Snippet.Thumbnails, Converter={StaticResource ThumbnailsToBitmapImageConverter}}"
-                                                    Stretch="UniformToFill" />
-                                    </Rectangle.Fill>
-                                </Rectangle>
+                                <Rectangle.Fill>
+                                    <ImageBrush ImageSource="{x:Bind Snippet.Thumbnails, Converter={StaticResource ThumbnailsToBitmapImageConverter}}"
+                                                Stretch="UniformToFill" />
+                                </Rectangle.Fill>
+                            </Rectangle>
                         </Viewbox>
-                        <Grid Background="{ThemeResource SystemControlBackgroundAltMediumBrush}" 
-                              Opacity="0.9" 
-                              VerticalAlignment="Bottom" 
+                        <Grid Background="{ThemeResource SystemControlBackgroundAltMediumBrush}"
+                              Opacity="0.9"
+                              VerticalAlignment="Bottom"
                               Height="24">
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center">
-                                <TextBlock Text="HD" FontWeight="SemiBold" Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
-                                <TextBlock Text="5:33" Margin="5,0,0,0" FontWeight="SemiBold" Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
+                            <StackPanel Orientation="Horizontal"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Center">
+                                <TextBlock Text="HD"
+                                           FontWeight="SemiBold"
+                                           Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+                                <TextBlock Text="5:33"
+                                           Margin="5,0,0,0"
+                                           FontWeight="SemiBold"
+                                           Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}" />
                             </StackPanel>
 
                         </Grid>
@@ -85,9 +92,10 @@
                         <TextBlock Text="&#10;&#10;"
                                    Margin="10"
                                    Grid.Row="1" />
-                        
-                        <StackPanel Margin="10" Grid.Row="1">
-                            
+
+                        <StackPanel Margin="10"
+                                    Grid.Row="1">
+
                             <TextBlock MaxLines="2"
                                        Text="{x:Bind Snippet.Title}"
                                        TextTrimming="CharacterEllipsis"
@@ -95,7 +103,7 @@
                                        FontSize="14"
                                        FontWeight="SemiBold"
                                        x:Phase="1" />
-                            
+
                             <TextBlock Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
                                        Text="{x:Bind Snippet.ChannelTitle}"
                                        TextTrimming="CharacterEllipsis"
@@ -103,26 +111,27 @@
                                        FontSize="12"
                                        x:Phase="2" />
 
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <StackPanel Orientation="Horizontal"
+                                        HorizontalAlignment="Center">
                                 <TextBlock Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
-                                       Text="{x:Bind Snippet.Title}"
-                                       TextTrimming="CharacterEllipsis"
-                                       TextWrapping="Wrap"
-                                       x:Phase="1"
-                                       Margin="0,0,5,0"/>
+                                           Text="{x:Bind Snippet.Title}"
+                                           TextTrimming="CharacterEllipsis"
+                                           TextWrapping="Wrap"
+                                           x:Phase="1"
+                                           Margin="0,0,5,0" />
 
-                                <TextBlock Text="●"/>
+                                <TextBlock Text="●" />
 
                                 <TextBlock Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
-                                       Text="{x:Bind Snippet.ChannelTitle}"
-                                       TextTrimming="CharacterEllipsis"
-                                       TextWrapping="NoWrap"
-                                       x:Phase="2"
-                                       Margin="5,0,0,0"/>
+                                           Text="{x:Bind Snippet.ChannelTitle}"
+                                           TextTrimming="CharacterEllipsis"
+                                           TextWrapping="NoWrap"
+                                           x:Phase="2"
+                                           Margin="5,0,0,0" />
                             </StackPanel>
 
                         </StackPanel>
-                        
+
                     </Grid>
                 </DataTemplate>
             </GridView.ItemTemplate>

--- a/UniTube/Views/SearchPage.xaml
+++ b/UniTube/Views/SearchPage.xaml
@@ -7,6 +7,7 @@
       xmlns:cu="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,5)"
       xmlns:fcu="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,5)"
       xmlns:resources="using:UniTube.Core.Resources"
+      xmlns:datatemplateselectors="using:UniTube.DataTemplateSelectors"
       mc:Ignorable="d">
 
     <Page.DataContext>
@@ -14,44 +15,9 @@
                  Source="{StaticResource Locator}" />
     </Page.DataContext>
 
-    <Grid>
-        
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup>
-                
-                <VisualState>
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                
-                <VisualState>
-                    
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="641" />
-                    </VisualState.StateTriggers>
-                    
-                    <VisualState.Setters>
-                        <Setter Target="SearchGridView.Padding"
-                                Value="20 20 5 15" />
-                    </VisualState.Setters>
-                    
-                </VisualState>
-                
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-
-        <GridView ItemsSource="{x:Bind ViewModel.SearchList, Mode=OneWay}"
-                  SelectionMode="None"
-                  IsItemClickEnabled="True"
-                  helpers:ListViewBehavior.FillBeforeWrap="True"
-                  helpers:ListViewBehavior.MinItemWidth="190"
-                  x:Name="SearchGridView"
-                  cu:ItemContainerStyle="{StaticResource StretchGridViewItemStyle}"
-                  fcu:ItemContainerStyle="{StaticResource StretchRevealGridViewItemStyle}"
-                  ItemContainerTransitions="{StaticResource GridViewItemContainerTransitions}"
-                  Padding="10 10 -5 5">
-            <GridView.ItemTemplate>
+    <Page.Resources>
+        <datatemplateselectors:ResourceTemplateSelector x:Key="ResourceTemplateSelector">
+            <datatemplateselectors:ResourceTemplateSelector.VideoTemplate>
                 <DataTemplate x:DataType="resources:Video">
                     <Grid Background="{ThemeResource SystemControlBackgroundChromeMediumBrush}">
 
@@ -112,12 +78,11 @@
 
                             <StackPanel Orientation="Horizontal"
                                         HorizontalAlignment="Center">
-                                
+
                                 <TextBlock Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
                                            Text="0 views"
                                            TextTrimming="CharacterEllipsis"
                                            TextWrapping="Wrap"
-                                           
                                            Margin="0,0,5,0" />
 
                                 <TextBlock Text="·" />
@@ -128,14 +93,61 @@
                                            TextWrapping="NoWrap"
                                            x:Phase="2"
                                            Margin="5,0,0,0" />
-                                
+
                             </StackPanel>
 
                         </StackPanel>
 
                     </Grid>
                 </DataTemplate>
-            </GridView.ItemTemplate>
+            </datatemplateselectors:ResourceTemplateSelector.VideoTemplate>
+            <datatemplateselectors:ResourceTemplateSelector.ChannelTemplate>
+                <DataTemplate />
+            </datatemplateselectors:ResourceTemplateSelector.ChannelTemplate>
+            <datatemplateselectors:ResourceTemplateSelector.PlaylistTemplate>
+                <DataTemplate />
+            </datatemplateselectors:ResourceTemplateSelector.PlaylistTemplate>
+        </datatemplateselectors:ResourceTemplateSelector>
+    </Page.Resources>
+    
+    <Grid>
+        
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                </VisualState>
+                
+                <VisualState>
+                    
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="641" />
+                    </VisualState.StateTriggers>
+                    
+                    <VisualState.Setters>
+                        <Setter Target="SearchGridView.Padding"
+                                Value="20 20 5 15" />
+                    </VisualState.Setters>
+                    
+                </VisualState>
+                
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
+        <GridView ItemsSource="{x:Bind ViewModel.SearchList, Mode=OneWay}"
+                  SelectionMode="None"
+                  IsItemClickEnabled="True"
+                  helpers:ListViewBehavior.FillBeforeWrap="True"
+                  helpers:ListViewBehavior.MinItemWidth="190"
+                  x:Name="SearchGridView"
+                  cu:ItemContainerStyle="{StaticResource StretchGridViewItemStyle}"
+                  fcu:ItemContainerStyle="{StaticResource StretchRevealGridViewItemStyle}"
+                  ItemContainerTransitions="{StaticResource GridViewItemContainerTransitions}"
+                  ItemTemplateSelector="{StaticResource ResourceTemplateSelector}"
+                  Padding="10 10 -5 5">
         </GridView>
     </Grid>
 </Page>

--- a/UniTube/Views/SearchPage.xaml
+++ b/UniTube/Views/SearchPage.xaml
@@ -112,14 +112,15 @@
 
                             <StackPanel Orientation="Horizontal"
                                         HorizontalAlignment="Center">
+                                
                                 <TextBlock Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
-                                           Text="{x:Bind Snippet.Title}"
+                                           Text="0 views"
                                            TextTrimming="CharacterEllipsis"
                                            TextWrapping="Wrap"
-                                           x:Phase="1"
+                                           
                                            Margin="0,0,5,0" />
 
-                                <TextBlock Text="●" />
+                                <TextBlock Text="·" />
 
                                 <TextBlock Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
                                            Text="{x:Bind Snippet.PublishedAt, Converter={StaticResource DateTimeToStringConverter}}"


### PR DESCRIPTION
# Changes
- **DataTemplateSelector** implemented on Search Page
- Fixed the **DateTimeToStringConverter**
- Updated Nugets

## DataTemplateSelector
The **DataTemplateSelector** allows to add different data types into a grid, and show different templates. This is implemented to show videos, channels and playlists in the GridView, without need to separate into multiple tabs